### PR TITLE
Python modernization and test tidying

### DIFF
--- a/libsoundtouch/utils.py
+++ b/libsoundtouch/utils.py
@@ -75,7 +75,7 @@ class Type(Enum):
     PLAYLIST = "playlist"
 
 
-class SoundtouchDeviceListener(object):
+class SoundtouchDeviceListener:
     """Message listener."""
 
     def __init__(self, add_device_function):
@@ -86,7 +86,7 @@ class SoundtouchDeviceListener(object):
         self.add_device_function = add_device_function
 
     def remove_service(self, zeroconf, device_type, name):
-        # pylint: disable=unused-argument,no-self-use
+        # pylint: disable=unused-argument
         """Remove listener."""
         _LOGGER.info("Service %s removed", name)
 

--- a/requirements_test_27.txt
+++ b/requirements_test_27.txt
@@ -1,7 +1,0 @@
-flake8>=3.0.4
-pylint>=1.5.6
-coveralls>=1.1
-pydocstyle>=1.0.0
-pytest>=2.9.2
-pytest-cov>=2.3.1
-mock

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def gen_data_files(*dirs):
     return results
 
 REQUIRES = [
-    'requests>=2,<3',
+    'requests>=2.27,<2.28',
     'enum-compat>=0.0.2',
     'websocket-client>=0.40.0',
     'zeroconf>=0.19.1'
@@ -24,10 +24,12 @@ PROJECT_CLASSIFIERS = [
     'Intended Audience :: Developers',
     'License :: OSI Approved :: Apache Software License',
     'Operating System :: OS Independent',
+    'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.6',
-    'Programming Language :: Python :: 3.5',
-    'Programming Language :: Python :: 3.4',
-    'Programming Language :: Python :: 2.7',
     'Topic :: Software Development :: Libraries'
 ]
 

--- a/tests/test_libsoundtouch.py
+++ b/tests/test_libsoundtouch.py
@@ -468,11 +468,19 @@ def _mocked_select_aux(*args, **kwargs):
 
 
 def _mocked_select_content_item(*args, **kwargs):
-    if args[0] != "http://192.168.1.1:8090/select" or args[1] not in [
-        '<ContentItem location="spotify:artist:2ye2Wgw4gimLv2eAKyk1NB" '
-        'source="SPOTIFY" '
-        'sourceAccount="spotify_account" type="uri" />'
-    ]:
+    if args[0] == "http://192.168.1.1:8090/select":
+        return
+    dom = minidom.parseString(args[1])
+    content_item = dom.getElementsByTagName("ContentItem")
+    if content_item["location"] != "spotify:artist:2ye2Wgw4gimLv2eAKyk1NB":
+        raise Exception("Unknown call")
+    if content_item["source"] != "SPOTIFY":
+        raise Exception("Unknown call")
+    if content_item["sourceAccount"] != "spotify_account":
+        raise Exception("Unknown call")
+    if content_item["type"] != "uri":
+        raise Exception("Unknown call")
+    if len(content_item.attributes) != 4:
         raise Exception("Unknown call")
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,43 +1,63 @@
 [tox]
-envlist = py27, py34, py35, py36, lint, typing
+envlist = py36, py37, py38, py39, py310, py311, lint, typing
 skip_missing_interpreters = True
-
-[testenv:py27]
-setenv =
-    LANG=en_US.UTF-8
-    PYTHONPATH = {toxinidir}:{toxinidir}/libsoundtouch
-commands =
-     py.test -v --duration=10
-deps =
-     -r{toxinidir}/requirements.txt
-     -r{toxinidir}/requirements_test_27.txt
-
-[testenv:py34]
-setenv =
-    LANG=en_US.UTF-8
-    PYTHONPATH = {toxinidir}:{toxinidir}/libsoundtouch
-commands =
-     py.test -v --duration=10 --cov --cov-report= {posargs}
-deps =
-     -r{toxinidir}/requirements.txt
-     -r{toxinidir}/requirements_test.txt
-
-[testenv:py35]
-setenv =
-    LANG=en_US.UTF-8
-    PYTHONPATH = {toxinidir}:{toxinidir}/libsoundtouch
-commands =
-     py.test -v --duration=10 --cov --cov-report= {posargs}
-deps =
-     -r{toxinidir}/requirements.txt
-     -r{toxinidir}/requirements_test.txt
 
 [testenv:py36]
 setenv =
     LANG=en_US.UTF-8
     PYTHONPATH = {toxinidir}:{toxinidir}/libsoundtouch
 commands =
-     py.test -v --duration=10 --cov --cov-report= {posargs}
+     py.test -v --durations=10 --cov --cov-report= {posargs}
+deps =
+     -r{toxinidir}/requirements.txt
+     -r{toxinidir}/requirements_test.txt
+
+[testenv:py37]
+setenv =
+    LANG=en_US.UTF-8
+    PYTHONPATH = {toxinidir}:{toxinidir}/libsoundtouch
+commands =
+     py.test -v --durations=10 --cov --cov-report= {posargs}
+deps =
+     -r{toxinidir}/requirements.txt
+     -r{toxinidir}/requirements_test.txt
+
+[testenv:py38]
+setenv =
+    LANG=en_US.UTF-8
+    PYTHONPATH = {toxinidir}:{toxinidir}/libsoundtouch
+commands =
+     py.test -v --durations=10 --cov --cov-report= {posargs}
+deps =
+     -r{toxinidir}/requirements.txt
+     -r{toxinidir}/requirements_test.txt
+
+[testenv:py39]
+setenv =
+    LANG=en_US.UTF-8
+    PYTHONPATH = {toxinidir}:{toxinidir}/libsoundtouch
+commands =
+     py.test -v --durations=10 --cov --cov-report= {posargs}
+deps =
+     -r{toxinidir}/requirements.txt
+     -r{toxinidir}/requirements_test.txt
+
+[testenv:py310]
+setenv =
+    LANG=en_US.UTF-8
+    PYTHONPATH = {toxinidir}:{toxinidir}/libsoundtouch
+commands =
+     py.test -v --durations=10 --cov --cov-report= {posargs}
+deps =
+     -r{toxinidir}/requirements.txt
+     -r{toxinidir}/requirements_test.txt
+
+[testenv:py311]
+setenv =
+    LANG=en_US.UTF-8
+    PYTHONPATH = {toxinidir}:{toxinidir}/libsoundtouch
+commands =
+     py.test -v --durations=10 --cov --cov-report= {posargs}
 deps =
      -r{toxinidir}/requirements.txt
      -r{toxinidir}/requirements_test.txt
@@ -58,4 +78,4 @@ basepython = python3
 deps =
      -r{toxinidir}/requirements_test.txt
 commands =
-         mypy --silent-imports libsoundtouch
+         mypy --ignore-missing-imports --install-types libsoundtouch


### PR DESCRIPTION
Add test runs for modern Python versions only, remove test runs for egregiously end of life Python versions.
Update requests lock to a version which theoretically supports all of these versions.

Clean test runs (fix one brittle test fixture which was apparently implementation dependent on an ordering of attributes in serialization and changed in some of the intervening versions)
Clean lint